### PR TITLE
実行のbinを明示的に指定

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,5 +16,6 @@
   "editor.codeActionsOnSave": {
     "quickfix.biome": "explicit",
     "source.organizeImports.biome": "explicit"
-  }
+  },
+  "biome.lsp.bin": "node_modules/.bin/biome"
 }


### PR DESCRIPTION
devコンテナで、IDEがbiomeの実行パス探せていなかったらしいので、明示。